### PR TITLE
Modified definition of HotwordListen and deleted Speak.action

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ add_action_files(DIRECTORY
 ```
 
 ## To do:
-- [ ] Add Listen.action and DetectNoiseDirection.action (speech)
+- [ ] Add KnockListen.action and DetectNoiseDirection.action (speech)
 - [ ] Add Navigation + Semantic mapping + high-level actions
 - [ ] Document the vision actions in the readme
 
@@ -121,10 +121,23 @@ add_action_files(DIRECTORY
 
 ### Speech Actions
 * Speak.action
-	- input: sentence (**string**)
-	- result: succeeded (**bool**)
-	- feedback: N/A
-	- notes: Speaks out the sentence given
+    - removed since HSR already defines an action server named ``/talk_request_action``. Actions are defined in ``tmc_msgs``. Any speech to the robot could be sent as below:
+    
+    
+    ```
+    from tmc_msgs.msg import TalkRequestAction, TalkRequestGoal, Voice
+    
+    talk_server = SimpleActionClient('talk_request_action', TalkRequestAction)
+    # ...
+    
+    talk_goal = TalkRequestGoal()
+    talk_goal.data.language = Voice.kEnglish
+    talk_goal.data.sentence = text
+    
+    talk_server.send_goal(talk_goal)
+    talk_server.wait_for_result()
+    ```
+	
 
 * SpeakAndListen.action
 	- input: question (**string**), candidates (**string[]**), params (**string[]**), timeout (**float32**),
@@ -134,8 +147,6 @@ add_action_files(DIRECTORY
 	
 * HotwordListen.action
 	- input: timeout (**float32**),
-	- result: confidence (**float32**), succeeded (**bool**)
-	- feedback: remaining (**float32**)
+	- result: succeeded (**bool**), hotword (**string**)
+	- feedback: N/A
 	- notes: Detects a hotword (predefined)
-	
-

--- a/orion_actions/CMakeLists.txt
+++ b/orion_actions/CMakeLists.txt
@@ -105,7 +105,6 @@ add_action_files(
   Navigate.action
   Follow.action
 
-  Speak.action
   SpeakAndListen.action
   HotwordListen.action
 )

--- a/orion_actions/action/HotwordListen.action
+++ b/orion_actions/action/HotwordListen.action
@@ -3,9 +3,7 @@
 float32 timeout
 --- 
 # Define the result
-float32 confidence
 bool succeeded
+string hotword
 ---
 # Define a feedback message
-# timeout or failure if remaining < 0
-float32 remaining

--- a/orion_actions/action/Speak.action
+++ b/orion_actions/action/Speak.action
@@ -1,7 +1,0 @@
-# Define the goal
-string sentence
---- 
-# Define the result
-bool succeeded
----
-# Define a feedback message


### PR DESCRIPTION
- Added detected hotword (string) in HotwordListenResult
- Removed Speak.action as it is a duplicate of TalkRequest.action defined in tmc_msgs (read README)