### PR TITLE
change size property of detection to point rather than float

### DIFF
--- a/orion_actions/msg/Detection.msg
+++ b/orion_actions/msg/Detection.msg
@@ -3,7 +3,7 @@ float64 x
 float64 y
 float64 width
 float64 height
-float64 size
+geometry_msgs/Point size
 string color
 float64 translation_x
 float64 translation_y


### PR DESCRIPTION
Want size to have 3 dimensions, in metres. Currently its a single dimensionless number. 